### PR TITLE
LED制御機能を追加し、外付けLEDの初期化と設定を実装

### DIFF
--- a/src/model_handler.c
+++ b/src/model_handler.c
@@ -263,7 +263,6 @@ const struct bt_mesh_comp *model_handler_init(void)
 	green_led_dev = DEVICE_DT_GET(GREEN_LED_NODE);
 	if (!device_is_ready(green_led_dev)) {
     	printk("Error: GPIO device not ready.\n");
-		printf("Error: GPIO device not ready\n");
 	}
 	gpio_pin_configure(green_led_dev, GREEN_LED_PIN, GPIO_OUTPUT_INACTIVE);
 

--- a/src/model_handler.c
+++ b/src/model_handler.c
@@ -106,7 +106,7 @@ static void led_set(struct bt_mesh_onoff_srv *srv, struct bt_mesh_msg_ctx *ctx,
 		// 緑LEDとled1が対応
 		if (led_idx == 1 && green_led_dev) {
     		gpio_pin_set(green_led_dev, GREEN_LED_PIN, set->on_off);
-    		printk("Green LED (P0.01) -> %d\n", set->on_off);
+    		printk("Green LED (P0.02) -> %d\n", set->on_off);
 		}
 		// 青LEDとled2が対応
 		if (led_idx == 2 && blue_led_dev) {

--- a/src/model_handler.c
+++ b/src/model_handler.c
@@ -111,7 +111,7 @@ static void led_set(struct bt_mesh_onoff_srv *srv, struct bt_mesh_msg_ctx *ctx,
 		// 青LEDとled2が対応
 		if (led_idx == 2 && blue_led_dev) {
     		gpio_pin_set(blue_led_dev, BLUE_LED_PIN, set->on_off);
-    		printk("Blue LED (P0.01) -> %d\n", set->on_off);
+    		printk("Blue LED (P0.03) -> %d\n", set->on_off);
 		}
 
 		goto respond;


### PR DESCRIPTION
nRF54L15 DKのPROT 0のPIN1-3に外付けのLEDを接続し，nRF Meshアプリで内蔵LEDと同時に点灯させることを可能とした．